### PR TITLE
Reduce stat calls

### DIFF
--- a/files.go
+++ b/files.go
@@ -5,26 +5,30 @@ import (
 	"io/fs"
 )
 
-type file struct {
-	fs.File
-
-	fs fs.FS
-}
-
-func (f *file) GetFs() fs.FS {
-	return f.fs
-}
-
 type dirFile struct {
-	file
+	fs.File
+	fs fs.FS
 
 	layerFs *layerFs
 	name    string
 }
 
+func (f *dirFile) GetFs() fs.FS {
+	return f.fs
+}
+
 func (f *dirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if n >= 0 {
 		return nil, errors.New("layerFilesystem: Could not ReadDir because n >= 0 is not supported")
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, newError("could not ReadDir because dirFile does not point to a directory", f.name)
 	}
 
 	return f.layerFs.ReadDir(f.name)

--- a/files.go
+++ b/files.go
@@ -1,7 +1,6 @@
 package layerfs
 
 import (
-	"errors"
 	"io/fs"
 )
 
@@ -19,7 +18,7 @@ func (f *dirFile) GetFs() fs.FS {
 
 func (f *dirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	if n >= 0 {
-		return nil, errors.New("layerFilesystem: Could not ReadDir because n >= 0 is not supported")
+		return nil, newError("could not ReadDir because n >= 0 is not supported", f.name)
 	}
 
 	info, err := f.Stat()

--- a/files.go
+++ b/files.go
@@ -8,7 +8,7 @@ type dirFile struct {
 	fs.File
 	fs fs.FS
 
-	layerFs *layerFs
+	layerFs *LayerFs
 	name    string
 }
 

--- a/fs.go
+++ b/fs.go
@@ -19,27 +19,12 @@ func (fsys *layerFs) Open(name string) (fs.File, error) {
 			continue
 		}
 
-		// TODO: we only need this to determine if we're dealing with a directory
-		// and that we only need for implementing ReadDirFileFS, should we make it optional?
-		info, err := f.Stat()
-		if err != nil {
-			return nil, err
-		}
-
-		file := file{
+		return &dirFile{
 			f,
 			layer,
-		}
-
-		if info.IsDir() {
-			return &dirFile{
-				file,
-				fsys,
-				name,
-			}, nil
-		}
-
-		return &file, nil
+			fsys,
+			name,
+		}, nil
 	}
 
 	return nil, newError("could not Open", name)

--- a/fs.go
+++ b/fs.go
@@ -44,13 +44,13 @@ func (fsys *layerFs) ReadFile(name string) ([]byte, error) {
 }
 
 func (fsys *layerFs) ReadDir(name string) ([]fs.DirEntry, error) {
-	entryMap := make(map[string]bool, 0)
+	entryMap := make(map[string]bool)
 	entries := make([]fs.DirEntry, 0)
 	errorLayers := 0
 	for _, layer := range fsys.layers {
 		layerEntries, err := fs.ReadDir(layer, name)
 		if err != nil {
-			errorLayers += 1
+			errorLayers++
 			continue
 		}
 		for _, layerEntry := range layerEntries {

--- a/fs.go
+++ b/fs.go
@@ -54,7 +54,7 @@ func (fsys *LayerFs) ReadFile(name string) ([]byte, error) {
 
 // ReadDir reads the named directory (implements fs.ReadDirFS).
 func (fsys *LayerFs) ReadDir(name string) ([]fs.DirEntry, error) {
-	entryMap := make(map[string]bool)
+	entryMap := map[string]bool{}
 	entries := make([]fs.DirEntry, 0)
 	errorLayers := 0
 	for _, layer := range fsys.layers {

--- a/fs_test.go
+++ b/fs_test.go
@@ -14,7 +14,7 @@ func assertContent(assert *assert.Assertions, filesystem fs.FS, fileName string,
 	assert.Equal(content, fileContent)
 }
 
-func setupTestFs(assert *assert.Assertions) *layerFs {
+func setupTestFs(assert *assert.Assertions) *LayerFs {
 	upperFs := memfs.New()
 	assert.Nil(upperFs.WriteFile("f1.txt", []byte("foo"), 0755))
 	assert.Nil(upperFs.WriteFile("f2.txt", []byte("foo"), 0755))

--- a/helpers.go
+++ b/helpers.go
@@ -5,7 +5,7 @@ import (
 )
 
 // use indirection over Info() because WalkDir creates a statDirEntry
-// wrapper and there's no way we can inject our own type there
+// wrapper and there's no way we can inject our own type there.
 func GetSourceFsForDirEntry(d fs.DirEntry) (fs.FS, error) {
 	info, err := d.Info()
 	if err != nil {


### PR DESCRIPTION
It is valid for any fs.File to implement fs.ReadDirFile even if it's not
a directory. We trade a bit of memory (for storing the path in every
file now) for less Stat calls which we can do on demand now.

c.f. https://cs.opensource.google/go/go/+/refs/tags/go1.17.3:src/io/fs/fs.go;l=108