### PR TITLE
Wrap file opening errors so that proper HTTP status codes can be given when using http.FS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.16, ^1]
+        go-version: [~1.17, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,17 +12,17 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           go test -race -covermode atomic -coverprofile=profile.cov ./...
-          GO111MODULE=off go get github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
           $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - goimports
     - goprintffuncname
     - gosec
-    - ifshort
     - misspell
     - prealloc
     - revive

--- a/errors.go
+++ b/errors.go
@@ -4,18 +4,28 @@ import (
 	"fmt"
 )
 
+func newError(text string, name string) error {
+	return fmt.Errorf("go-layerfs: %s: %s", text, name)
+}
+
 type layerFsError struct {
 	name string
 	text string
+	err  error
 }
 
-func newError(text string, name string) error {
+func wrapError(err error, text string, name string) error {
 	return &layerFsError{
 		text: text,
 		name: name,
+		err:  err,
 	}
 }
 
 func (l *layerFsError) Error() string {
 	return fmt.Sprintf("go-layerfs: %s: %s", l.text, l.name)
+}
+
+func (l *layerFsError) Unwrap() error {
+	return l.err
 }

--- a/fs.go
+++ b/fs.go
@@ -1,8 +1,6 @@
 package layerfs
 
-import (
-	"io/fs"
-)
+import "io/fs"
 
 // New creates a new LayerFs instance based on 0-n fs.FS layers.
 func New(layers ...fs.FS) *LayerFs {
@@ -21,8 +19,10 @@ type LayerFs struct {
 
 // Open opens the named file (implements fs.FS).
 func (fsys *LayerFs) Open(name string) (fs.File, error) {
+	var err error
 	for _, layer := range fsys.layers {
-		f, err := layer.Open(name)
+		var f fs.File
+		f, err = layer.Open(name)
 		if err != nil {
 			continue
 		}
@@ -35,7 +35,7 @@ func (fsys *LayerFs) Open(name string) (fs.File, error) {
 		}, nil
 	}
 
-	return nil, newError("could not Open", name)
+	return nil, wrapError(err, "could not Open", name)
 }
 
 // ReadFile reads the named file and returns its contents (implements fs.ReadFileFS).

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -49,6 +49,7 @@ func TestGetFsForDirEntry(t *testing.T) {
 	fsys := memfs.New()
 	assert.Nil(fsys.MkdirAll("dir1", 0777))
 	entries, err = fs.ReadDir(fsys, ".")
+	assert.Nil(err)
 	_, err = GetLayerForDirEntry(entries[0])
 	assert.Equal("go-layerfs: Could not assert DirEntry type: dir1", err.Error())
 }


### PR DESCRIPTION
I had a problem when using a LayerFs with http.FS to serve up assets. If someone requested an asset that did not exist, instead of getting a 404 they would get a 500. By wrapping the errors, the http.FS code can now Unwrap() them to get the underlying fs error and determine the proper status code to serve.